### PR TITLE
Improve booking form address fallback and add smoke test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
-    "playwright": "^1.49.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test:booking": "node scripts/test-booking-form.js"
   },
   "dependencies": {
     "@getbrevo/brevo": "^3.0.1",
@@ -31,6 +32,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.0.1",
+    "playwright": "^1.49.0",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.8",
     "typescript": "^5"

--- a/scripts/test-booking-form.js
+++ b/scripts/test-booking-form.js
@@ -1,7 +1,16 @@
 #!/usr/bin/env node
 /* eslint-disable no-console */
 
-const { chromium } = require("playwright");
+let chromium;
+
+try {
+  ({ chromium } = require("playwright"));
+} catch (error) {
+  console.error(
+    "Playwright is required to run this script. Install it with `pnpm add -D playwright` and try again.",
+  );
+  process.exit(1);
+}
 
 async function run() {
   const baseUrl = process.env.BOOKING_FORM_URL || "http://localhost:3000";

--- a/scripts/test-booking-form.js
+++ b/scripts/test-booking-form.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const { chromium } = require("playwright");
+
+async function run() {
+  const baseUrl = process.env.BOOKING_FORM_URL || "http://localhost:3000";
+  const sendRealSubmission = process.env.BOOKING_FORM_REAL_SUBMISSION === "true";
+
+  console.log(`Opening ${baseUrl} to exercise the booking form...`);
+
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage();
+  page.setDefaultTimeout(15000);
+
+  try {
+    await page.goto(baseUrl, { waitUntil: "networkidle" });
+
+    const contactInput = page.locator("#contact-name");
+    await contactInput.waitFor({ state: "visible" });
+    await contactInput.fill("Test Business");
+
+    const sizeButton = page.getByRole("button", { name: /10.?yard/i });
+    await sizeButton.click();
+
+    const addressInput = page.getByPlaceholder(/Waterbury/i);
+    await addressInput.fill("123 Main St, Waterbury, CT 06702");
+    await addressInput.blur();
+
+    const phoneInput = page.getByPlaceholder("(555) 123-4567");
+    await phoneInput.fill("2035550123");
+
+    const emailInput = page.getByPlaceholder("you@email.com");
+    await emailInput.fill("test@example.com");
+
+    const submitButton = page.getByRole("button", { name: /Request dumpster/ });
+    await submitButton.waitFor({ state: "visible" });
+
+    console.log(
+      `Submitting booking form in ${sendRealSubmission ? "live" : "simulation"} mode...`,
+    );
+    await submitButton.click({
+      modifiers: sendRealSubmission ? [] : ["Shift"],
+    });
+
+    const animatedTruck = submitButton.locator("svg").first();
+    await animatedTruck.waitFor({ state: "visible" });
+    const animationClass = await animatedTruck.getAttribute("class");
+
+    if (!animationClass || !animationClass.includes("animate")) {
+      throw new Error("Truck animation did not start after submission.");
+    }
+    console.log("Truck animation detected.");
+
+    await page.getByRole("button", { name: /Requested!/ }).waitFor({ state: "visible" });
+    console.log("Form reached success state. Test complete.");
+  } finally {
+    await page.close();
+    await browser.close();
+  }
+}
+
+run()
+  .then(() => {
+    console.log("Booking form smoke test finished successfully.");
+  })
+  .catch((error) => {
+    console.error("Booking form smoke test failed:", error);
+    process.exitCode = 1;
+  });

--- a/src/actions/orders.ts
+++ b/src/actions/orders.ts
@@ -48,7 +48,10 @@ export async function submitOrder(formData: {
   try {
     const sendSmtpEmail = new brevo.SendSmtpEmail();
     sendSmtpEmail.sender = { name: 'Presidential Dumpsters', email: 'contact@digidov.com' };
-    sendSmtpEmail.to = [{ email: 'office@presidentialmgmt.com', name: 'Presidential Management' }];
+    sendSmtpEmail.to = [
+      { email: 'office@presidentialmgmt.com', name: 'Presidential Management' },
+      { email: 'dovindustries@gmail.com', name: 'dovindustries' },
+    ];
     sendSmtpEmail.subject = `New Dumpster Order - ${dumpster.name}${
       trimmedContact ? ` for ${trimmedContact}` : ''
     }`;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -37,12 +37,6 @@ export default function PresidentialDumpsters() {
         <article className="space-y-12">
           <FadeIn>
             <header className="space-y-8">
-              {/* Badge */}
-              <span className="inline-flex items-center gap-2 rounded-full border border-emerald-400/20 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-300 backdrop-blur-sm">
-                <Truck className="h-4 w-4" aria-hidden="true" />
-                Professional Dumpster Services
-              </span>
-
               {/* Headline */}
               <h1 className="text-7xl font-bold leading-[1.05] tracking-[-0.03em] text-white md:text-8xl lg:text-[96px]">
                 Dumpster rentals in{" "}

--- a/src/components/AddressAutocomplete.tsx
+++ b/src/components/AddressAutocomplete.tsx
@@ -1,12 +1,13 @@
-'use client';
+"use client";
 
-import { useEffect, useRef, useState } from 'react';
-import { Loader } from '@googlemaps/js-api-loader';
+import { useEffect, useRef, useState } from "react";
+import { Loader } from "@googlemaps/js-api-loader";
 
 interface AddressAutocompleteProps {
   value: string;
   onChange: (address: string, details?: google.maps.places.PlaceResult) => void;
   onSelectionChange?: (wasSelected: boolean) => void;
+  onReadyChange?: (isReady: boolean) => void;
   placeholder?: string;
   className?: string;
 }
@@ -15,53 +16,103 @@ export default function AddressAutocomplete({
   value,
   onChange,
   onSelectionChange,
+  onReadyChange,
   placeholder = "Enter delivery address",
-  className
+  className,
 }: AddressAutocompleteProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [isLoaded, setIsLoaded] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
 
   useEffect(() => {
+    let isMounted = true;
+
     const loader = new Loader({
-      apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || '',
-      version: 'weekly',
-      libraries: ['places']
+      apiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || "",
+      version: "weekly",
+      libraries: ["places"],
     });
 
-    loader.load().then(() => {
-      if (!inputRef.current) return;
+    loader
+      .load()
+      .then(() => {
+        if (!isMounted || !inputRef.current) return;
 
-      const autocomplete = new google.maps.places.Autocomplete(inputRef.current, {
-        types: ['address'],
-        componentRestrictions: { country: 'US' }
+        const autocomplete = new google.maps.places.Autocomplete(
+          inputRef.current,
+          {
+            types: ["address"],
+            componentRestrictions: { country: "US" },
+          },
+        );
+
+        autocomplete.addListener("place_changed", () => {
+          const place = autocomplete.getPlace();
+          if (place.formatted_address) {
+            onChange(place.formatted_address, place);
+            onSelectionChange?.(true);
+          }
+        });
+
+        setIsLoaded(true);
+        setLoadFailed(false);
+        onReadyChange?.(true);
+      })
+      .catch((error) => {
+        console.error("Error loading Google Maps API:", error);
+        if (!isMounted) return;
+
+        setIsLoaded(false);
+        setLoadFailed(true);
+        onReadyChange?.(false);
       });
 
-      autocomplete.addListener('place_changed', () => {
-        const place = autocomplete.getPlace();
-        if (place.formatted_address) {
-          onChange(place.formatted_address, place);
-          onSelectionChange?.(true);
-        }
-      });
+    return () => {
+      isMounted = false;
+    };
+  }, [onChange, onSelectionChange, onReadyChange]);
 
-      setIsLoaded(true);
-    }).catch((error) => {
-      console.error('Error loading Google Maps API:', error);
-    });
-  }, [onChange, onSelectionChange]);
+  const handleManualSelection = (nextValue: string) => {
+    if (!isLoaded) {
+      const isComplete = nextValue.split(",").length >= 2 && nextValue.length > 15;
+      onSelectionChange?.(isComplete);
+    } else {
+      onSelectionChange?.(false);
+    }
+  };
+
+  const mergedClassName = [
+    className,
+    isLoaded ? "opacity-100" : loadFailed ? "opacity-100" : "opacity-85",
+  ]
+    .filter(Boolean)
+    .join(" ");
 
   return (
     <input
       ref={inputRef}
       type="text"
       value={value}
-      onChange={(e) => {
-        onChange(e.target.value);
-        onSelectionChange?.(false);
+      onChange={(event) => {
+        const nextValue = event.target.value;
+        onChange(nextValue);
+        handleManualSelection(nextValue);
       }}
-      placeholder={isLoaded ? placeholder : "Loading address lookup..."}
-      className={`${className} ${isLoaded ? 'opacity-100' : 'opacity-70'}`}
-      disabled={!isLoaded}
+      onBlur={() => {
+        if (!isLoaded) {
+          const isComplete = value.split(",").length >= 2 && value.length > 15;
+          onSelectionChange?.(isComplete);
+        }
+      }}
+      placeholder={
+        isLoaded
+          ? placeholder
+          : loadFailed
+          ? "Enter delivery address (manual entry)"
+          : "Loading address lookup..."
+      }
+      autoComplete="street-address"
+      className={mergedClassName}
     />
   );
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -70,10 +70,21 @@ export const validateContactName = (name: string, bookingType: BookingType): str
   return null;
 };
 
-export const validateAddress = (address: string, wasSelected: boolean): string | null => {
-  if (!wasSelected || address.split(',').length < 2 || address.length < 15) {
+export const validateAddress = (
+  address: string,
+  wasSelected: boolean,
+  allowManualFallback = false,
+): string | null => {
+  const looksComplete = address.split(',').length >= 2 && address.length >= 15;
+
+  if (allowManualFallback && looksComplete) {
+    return null;
+  }
+
+  if (!wasSelected || !looksComplete) {
     return 'Please select a full address from the dropdown';
   }
+
   return null;
 };
 


### PR DESCRIPTION
## Summary
- allow the booking form to fall back to manual address entry when Places autocomplete is unavailable while still using the dropdown when ready
- copy internal order notifications to dovindustries@gmail.com
- add a Playwright-powered smoke test script and npm script for exercising the booking form and truck animation

## Testing
- pnpm lint *(fails: existing ESLint config circular structure error)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6917935f4764832bac89d0d6fcdcb6bf)