### PR TITLE
Polish UI/UX: form copy, sizing card color, image config, reduced motion

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -9,6 +9,7 @@ const nextConfig: NextConfig = {
     formats: ['image/avif', 'image/webp'],
     deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
     imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+    qualities: [75, 100],
     minimumCacheTTL: 60,
   },
 

--- a/src/app/sizing-guide/page.tsx
+++ b/src/app/sizing-guide/page.tsx
@@ -96,7 +96,7 @@ export default function SizingGuidePage() {
               </LiquidGlassCard>
 
               {/* 15-Yard */}
-              <LiquidGlassCard variant="accent">
+              <LiquidGlassCard variant="teal">
                 <div className="space-y-6">
                   <div className="flex items-baseline justify-between">
                     <h2 className="text-3xl font-bold text-white">15-Yard</h2>
@@ -108,19 +108,19 @@ export default function SizingGuidePage() {
                       <h3 className="text-sm font-bold text-white mb-3 uppercase tracking-wide">Perfect For:</h3>
                       <ul className="space-y-2">
                         <li className="flex items-start gap-2">
-                          <span className="text-emerald-400 mt-1">•</span>
+                          <span className="text-teal-300 mt-1">•</span>
                           <span>Whole-room remodels</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-emerald-400 mt-1">•</span>
+                          <span className="text-teal-300 mt-1">•</span>
                           <span>Whole-home cleanouts</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-emerald-400 mt-1">•</span>
+                          <span className="text-teal-300 mt-1">•</span>
                           <span>Deck and fence tear-outs</span>
                         </li>
                         <li className="flex items-start gap-2">
-                          <span className="text-emerald-400 mt-1">•</span>
+                          <span className="text-teal-300 mt-1">•</span>
                           <span>Mid-size construction debris</span>
                         </li>
                       </ul>

--- a/src/components/BookingFormCard.tsx
+++ b/src/components/BookingFormCard.tsx
@@ -387,7 +387,6 @@ export function BookingFormCard({ addressPlaceholder = "123 Main St, Waterbury" 
               active={currentStep === 4}
               complete={isStep4Complete}
             />
-            <p className="text-xs text-slate-500">Rental includes seven days on site.</p>
             <div className="space-y-3">
               <div className="space-y-2">
                 <input

--- a/src/components/FadeIn.tsx
+++ b/src/components/FadeIn.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion, useInView } from "framer-motion";
+import { motion, useInView, useReducedMotion } from "framer-motion";
 import { useRef, ReactNode } from "react";
 
 interface FadeInProps {
@@ -20,6 +20,7 @@ export function FadeIn({
 }: FadeInProps) {
   const ref = useRef(null);
   const isInView = useInView(ref, { once: true, margin: "-100px" });
+  const shouldReduceMotion = useReducedMotion();
 
   const directions = {
     up: { y: 40, x: 0 },
@@ -30,16 +31,22 @@ export function FadeIn({
   };
 
   const initialOffset = directions[direction];
+  const visible = { opacity: 1, y: 0, x: 0 };
+
+  // Respect reduced-motion: render content visible immediately, no transform.
+  if (shouldReduceMotion) {
+    return (
+      <motion.div ref={ref} initial={false} animate={visible} className={className}>
+        {children}
+      </motion.div>
+    );
+  }
 
   return (
     <motion.div
       ref={ref}
       initial={{ opacity: 0, ...initialOffset }}
-      animate={
-        isInView
-          ? { opacity: 1, y: 0, x: 0 }
-          : { opacity: 0, ...initialOffset }
-      }
+      animate={isInView ? visible : { opacity: 0, ...initialOffset }}
       transition={{
         duration,
         delay,

--- a/src/components/LiquidGlassCard.tsx
+++ b/src/components/LiquidGlassCard.tsx
@@ -6,7 +6,7 @@ import { motion } from "framer-motion";
 interface LiquidGlassCardProps {
   children: ReactNode;
   className?: string;
-  variant?: "default" | "accent" | "blue";
+  variant?: "default" | "accent" | "teal" | "blue";
 }
 
 export function LiquidGlassCard({
@@ -26,6 +26,12 @@ export function LiquidGlassCard({
       background: "rgba(16, 185, 129, 0.15)",
       shadowBase: "0 4px 30px rgba(16, 185, 129, 0.12)",
       shadowHover: "0 8px 40px rgba(16, 185, 129, 0.18)",
+    },
+    teal: {
+      border: "rgba(20, 184, 166, 0.2)",
+      background: "rgba(20, 184, 166, 0.15)",
+      shadowBase: "0 4px 30px rgba(20, 184, 166, 0.12)",
+      shadowHover: "0 8px 40px rgba(20, 184, 166, 0.18)",
     },
     blue: {
       border: "rgba(10, 33, 71, 0.2)",


### PR DESCRIPTION
Follow-up UI/UX cleanup after the pricing update, addressing four items from the review.

## Changes

1. **Booking form copy** — Removed the duplicate "Rental includes seven days on site." line from Step 4. The full rental terms (2 tons included, $145/ton overage, 7-day rental + $10/day, no concrete/hazmat) already live under Step 2, so the two phrasings no longer compete a few inches apart.

2. **Sizing-card color logic** — The new 15-yard card previously reused the green `accent` style, leaving two greens next to one blue. Added a `teal` variant to `LiquidGlassCard` and applied it (card + bullet accents) so the cards now read **green → teal → blue** by size, making the progression feel intentional.

3. **Next.js image config** — Added `images.qualities: [75, 100]` to `next.config.ts`. `logo.png` and the bear image use `quality={100}`, which Next 16 was clamping/warning about because only `[75]` was allowed.

4. **Reduced-motion accessibility** — `FadeIn` now respects `prefers-reduced-motion`: when requested, content renders immediately at full opacity with no transform, instead of relying on the scroll-triggered fade.

## Notes
- Items 3 and 4 were pre-existing issues (not introduced by the pricing change), flagged during the site review.
- `tsc --noEmit` passes. Local dev-server screenshots weren't possible this round (the sandbox reaps the dev process on startup), but the `teal` variant is a direct structural copy of the existing `accent`/`blue` variants and the 3-card layout was verified visually in the prior round.

https://claude.ai/code/session_01LihGbdbDirSdZpkwbpRP9K

---
_Generated by [Claude Code](https://claude.ai/code/session_01LihGbdbDirSdZpkwbpRP9K)_