### PR TITLE
Add automatic 6.35% CT sales tax at checkout

### DIFF
--- a/src/actions/orders.ts
+++ b/src/actions/orders.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import * as brevo from '@getbrevo/brevo';
-import { dumpsters, DumpsterSize } from '@/utils/pricing';
+import { dumpsters, DumpsterSize, calculateTax, calculateTotal } from '@/utils/pricing';
 import { BookingType } from '@/utils/validation';
 import {
   buildCustomerConfirmationHtml,
@@ -31,12 +31,16 @@ export async function submitOrder(formData: {
 
   const dumpster = dumpsters[selectedSize];
   const basePrice = dumpster.base;
+  const salesTaxAmount = calculateTax(basePrice);
+  const totalPrice = calculateTotal(basePrice);
   const trimmedContact = contactName.trim();
   const customerEmail = email.trim();
   const bookingDescriptor = bookingType === 'business' ? 'Business' : 'Residential';
   const emailContext = {
     dumpsterName: dumpster.name,
     basePrice,
+    salesTaxAmount,
+    totalPrice,
     bookingDescriptor,
     contactName: trimmedContact,
     address,

--- a/src/components/BookingFormCard.tsx
+++ b/src/components/BookingFormCard.tsx
@@ -9,6 +9,10 @@ import {
   overagePerTon,
   includedRentalDays,
   extraDayRate,
+  salesTaxRate,
+  calculateTax,
+  calculateTotal,
+  formatUsd,
 } from "@/utils/pricing";
 import { formatPhoneNumber, validateContactName, validateAddress, validatePhone, validateEmail } from "@/utils/validation";
 import { handleOrderWithUI, BookingData } from "@/utils/order-handler";
@@ -75,6 +79,9 @@ export function BookingFormCard({ addressPlaceholder = "123 Main St, Waterbury" 
   const [submitSuccess, setSubmitSuccess] = useState(false);
 
   const basePrice = selectedSize ? dumpsters[selectedSize].base : 0;
+  const salesTax = calculateTax(basePrice);
+  const totalPrice = calculateTotal(basePrice);
+  const taxRateLabel = `${(salesTaxRate * 100).toFixed(2).replace(/\.?0+$/, "")}%`;
   const contactPlaceholder = booking.bookingType === "business" ? "Acme Builders" : "Alex Johnson";
   const phoneDigits = booking.phone.replace(/[^\d]/g, "");
   const isStep1Complete = booking.contactName.trim().length > 0;
@@ -86,7 +93,9 @@ export function BookingFormCard({ addressPlaceholder = "123 Main St, Waterbury" 
     : addressLooksComplete;
   const isStep4Complete = phoneDigits.length >= 10 && booking.email.trim().length > 0;
   const currentStep = !isStep1Complete ? 1 : !isStep2Complete ? 2 : !isStep3Complete ? 3 : !isStep4Complete ? 4 : 4;
-  const ctaLabel = selectedSize ? `Request dumpster • $${basePrice}` : "Request dumpster";
+  const ctaLabel = selectedSize
+    ? `Request dumpster • ${formatUsd(totalPrice)}`
+    : "Request dumpster";
 
   useEffect(() => {
     if (isAddressAutocompleteReady) {
@@ -445,6 +454,22 @@ export function BookingFormCard({ addressPlaceholder = "123 Main St, Waterbury" 
           </div>
 
           <div className="space-y-3">
+            {selectedSize && (
+              <div className="rounded-2xl border border-slate-200/60 bg-white/70 px-5 py-4 text-sm">
+                <div className="flex items-center justify-between text-slate-600">
+                  <span>Base price</span>
+                  <span className="tabular-nums">{formatUsd(basePrice)}</span>
+                </div>
+                <div className="mt-2 flex items-center justify-between text-slate-600">
+                  <span>CT sales tax ({taxRateLabel})</span>
+                  <span className="tabular-nums">{formatUsd(salesTax)}</span>
+                </div>
+                <div className="mt-3 flex items-center justify-between border-t border-slate-200/70 pt-3 text-base font-semibold text-slate-900">
+                  <span>Total</span>
+                  <span className="tabular-nums">{formatUsd(totalPrice)}</span>
+                </div>
+              </div>
+            )}
             <button
               type="button"
               onClick={handleOrder}

--- a/src/utils/email-templates.ts
+++ b/src/utils/email-templates.ts
@@ -1,6 +1,10 @@
+import { salesTaxRate } from "./pricing";
+
 interface OrderEmailContext {
   dumpsterName: string;
   basePrice: number;
+  salesTaxAmount: number;
+  totalPrice: number;
   bookingDescriptor: string;
   contactName: string;
   address: string;
@@ -9,10 +13,17 @@ interface OrderEmailContext {
   notes: string;
 }
 
+const taxRateLabel = `${(salesTaxRate * 100).toFixed(2).replace(/\.?0+$/, "")}%`;
+
+const formatMoney = (amount: number) =>
+  amount.toLocaleString("en-US", { style: "currency", currency: "USD" });
+
 export const buildInternalOrderHtml = (context: OrderEmailContext) => {
   const {
     dumpsterName,
     basePrice,
+    salesTaxAmount,
+    totalPrice,
     bookingDescriptor,
     contactName,
     address,
@@ -27,7 +38,11 @@ export const buildInternalOrderHtml = (context: OrderEmailContext) => {
 
       <div style="background: #f9f9f9; padding: 15px; margin: 15px 0;">
         <p><strong>Dumpster Size:</strong> ${dumpsterName}</p>
-        <p><strong>Base Price:</strong> $${basePrice}</p>
+        <p><strong>Base Price:</strong> ${formatMoney(basePrice)}</p>
+        <p><strong>CT Sales Tax (${taxRateLabel}):</strong> ${formatMoney(
+    salesTaxAmount,
+  )}</p>
+        <p><strong>Total:</strong> ${formatMoney(totalPrice)}</p>
         <p><strong>Booking Type:</strong> ${bookingDescriptor}${
     contactName ? ` - ${contactName}` : ""
   }</p>
@@ -54,6 +69,8 @@ export const buildCustomerConfirmationHtml = (context: OrderEmailContext) => {
   const {
     dumpsterName,
     basePrice,
+    salesTaxAmount,
+    totalPrice,
     bookingDescriptor,
     contactName,
     address,
@@ -70,7 +87,11 @@ export const buildCustomerConfirmationHtml = (context: OrderEmailContext) => {
     contactName ? ` - ${contactName}` : ""
   }</p>
         <p><strong>Delivery address:</strong> ${address}</p>
-        <p><strong>Base price:</strong> $${basePrice}</p>
+        <p><strong>Base price:</strong> ${formatMoney(basePrice)}</p>
+        <p><strong>CT sales tax (${taxRateLabel}):</strong> ${formatMoney(
+    salesTaxAmount,
+  )}</p>
+        <p><strong>Total:</strong> ${formatMoney(totalPrice)}</p>
         <p><strong>Phone:</strong> ${phone}</p>
         ${notes ? `<p><strong>Notes you shared:</strong> ${notes}</p>` : ""}
       </div>

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -12,4 +12,19 @@ export const overagePerTon = 145;
 export const includedRentalDays = 7;
 export const extraDayRate = 10;
 
+// Connecticut state sales tax, applied automatically at checkout.
+export const salesTaxRate = 0.0635;
+
+/** Sales tax owed on a pre-tax amount, rounded to cents. */
+export const calculateTax = (preTax: number) =>
+  Math.round(preTax * salesTaxRate * 100) / 100;
+
+/** Pre-tax amount plus sales tax, rounded to cents. */
+export const calculateTotal = (preTax: number) =>
+  Math.round((preTax + calculateTax(preTax)) * 100) / 100;
+
+/** Format a dollar amount as USD currency (e.g. 611.51 -> "$611.51"). */
+export const formatUsd = (amount: number) =>
+  amount.toLocaleString('en-US', { style: 'currency', currency: 'USD' });
+
 export { dumpsters };


### PR DESCRIPTION
Customers now see a base / tax / total breakdown when they pick a
dumpster size, and the request CTA reflects the tax-inclusive total.
Both the internal order email and customer confirmation now itemize
the Connecticut sales tax and grand total.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PSshoPELVWyRrakxX9byJx